### PR TITLE
Add `ens.proto`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,21 @@
+name: Rust
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Protoc
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build
+      working-directory: rust/llt-proto
+      run: cargo build --verbose

--- a/ens/ens.proto
+++ b/ens/ens.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package ens;
+
+enum Error {
+    Unknown = 0;
+    ConnectionLimitReached = 1;
+    ServerMaintenance = 2;        // Only this error type can cause automatic recconection to a different server
+    Unauthenticated = 3;
+    Superseded = 4;
+}
+
+message ConnectionErrorRequest {}
+
+message ConnectionError {
+    Error code = 1;
+    optional string additional_info = 2;
+}
+
+message ChallengeRequest {}
+
+message ChallengeResponse {
+    string challenge = 1;
+}
+
+service Login {
+    rpc GetChallenge(ChallengeRequest) returns (ChallengeResponse);
+}
+
+service ENS {
+    rpc ConnectionErrors(ConnectionErrorRequest) returns (stream ConnectionError);
+}

--- a/rust/llt-proto/.gitignore
+++ b/rust/llt-proto/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/rust/llt-proto/Cargo.toml
+++ b/rust/llt-proto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "llt-proto"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+
+[dependencies]
+prost = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
+
+[build-dependencies]
+anyhow = "1"
+tonic-prost-build = "0.14"

--- a/rust/llt-proto/build.rs
+++ b/rust/llt-proto/build.rs
@@ -1,22 +1,13 @@
 use anyhow::Result;
-use std::{
-    env,
-    fs::create_dir,
-    io::{Error, ErrorKind},
-    path::Path,
-};
+
+const PROTO_PATH: &str = "../../ens/ens.proto";
 
 fn main() -> Result<()> {
-    let out_dir = format!(
-        "{}/protos",
-        env::var("OUT_DIR").map_err(|err| Error::other(err.to_string()))?
-    );
-    create_dir(Path::new(&out_dir)).or_else(|err| match err.kind() {
-        ErrorKind::AlreadyExists => Ok(()),
-        _ => Err(err),
-    })?;
+    tonic_prost_build::configure().compile_protos(&[PROTO_PATH], &["../../ens"])?;
 
-    tonic_prost_build::configure().compile_protos(&["../../ens/ens.proto"], &["../../ens"])?;
+    // This makes it possible to find the 'ens.proto' in the target directory
+    let out = std::env::var("OUT_DIR")?;
+    std::fs::copy(PROTO_PATH, format!("{out}/ens.proto"))?;
 
     Ok(())
 }

--- a/rust/llt-proto/build.rs
+++ b/rust/llt-proto/build.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use std::{
+    env,
+    fs::create_dir,
+    io::{Error, ErrorKind},
+    path::Path,
+};
+
+fn main() -> Result<()> {
+    let out_dir = format!(
+        "{}/protos",
+        env::var("OUT_DIR").map_err(|err| Error::other(err.to_string()))?
+    );
+    create_dir(Path::new(&out_dir)).or_else(|err| match err.kind() {
+        ErrorKind::AlreadyExists => Ok(()),
+        _ => Err(err),
+    })?;
+
+    tonic_prost_build::configure().compile_protos(&["../../ens/ens.proto"], &["../../ens"])?;
+
+    Ok(())
+}

--- a/rust/llt-proto/src/lib.rs
+++ b/rust/llt-proto/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod ens {
+    tonic::include_proto!("ens");
+}


### PR DESCRIPTION
`ens.proto` is used both on server and client side. To avoid duplications and risk of diverging from the common understanding, we shall use one shared definition file.

To make it easier to use this repo by rust projects, in addition to the proto file a simple wrapping rust crate is provided.